### PR TITLE
fix(README): Fix path of go install lazypg

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ brew install rebelice/tap/lazypg
 ### Go Install
 
 ```bash
-go install github.com/rebelice/lazypg@latest
+go install github.com/rebelice/lazypg/cmd/lazypg@latest
 ```
 
 ### Download Binary


### PR DESCRIPTION

The fix updates the command to point to the correct package under `cmd/lazypg`, where the CLI entry point is defined.

---

## ✅ What was changed
- Fixed the `go install` command in the README
- Ensured compatibility with Go Modules using `@latest`
- Improved the installation experience for new users

---

## 💡 Motivation
This change prevents installation errors and follows the standard Go CLI project structure, where binaries are usually located under `cmd/<cli-name>`.

---

## 🧪 How to test
```bash
go install github.com/rebelice/lazypg/cmd/lazypg@latest


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to specify a more targeted module path for the installation process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->