### PR TITLE
fix(data): display UUID values in standard format

### DIFF
--- a/internal/db/metadata/data.go
+++ b/internal/db/metadata/data.go
@@ -98,6 +98,9 @@ func convertValueToString(val interface{}) string {
 			return fmt.Sprintf("%v", val)
 		}
 		return string(jsonBytes)
+	case [16]byte:
+		// UUID from PostgreSQL
+		return fmt.Sprintf("%x-%x-%x-%x-%x", v[:4], v[4:6], v[6:8], v[8:10], v[10:])
 	case []byte:
 		// Might be raw JSON bytes
 		return string(v)

--- a/internal/db/query/executor.go
+++ b/internal/db/query/executor.go
@@ -79,6 +79,9 @@ func convertValueToString(val interface{}) string {
 			return fmt.Sprintf("%v", val)
 		}
 		return string(jsonBytes)
+	case [16]byte:
+		// UUID from PostgreSQL
+		return fmt.Sprintf("%x-%x-%x-%x-%x", v[:4], v[4:6], v[6:8], v[8:10], v[10:])
 	case []byte:
 		// Might be raw JSON bytes
 		return string(v)

--- a/internal/ui/components/table_view_pin_test.go
+++ b/internal/ui/components/table_view_pin_test.go
@@ -128,7 +128,7 @@ func TestTableView_IsPinned(t *testing.T) {
 	tv.SetData(columns, rows, 3)
 
 	tv.SelectedRow = 1
-	tv.TogglePin()
+	_ = tv.TogglePin()
 
 	if !tv.IsPinned(1) {
 		t.Fatal("row 1 should be pinned")
@@ -153,9 +153,9 @@ func TestTableView_ClearPins(t *testing.T) {
 
 	// Pin multiple rows
 	tv.SelectedRow = 0
-	tv.TogglePin()
+	_ = tv.TogglePin()
 	tv.SelectedRow = 1
-	tv.TogglePin()
+	_ = tv.TogglePin()
 
 	if tv.GetPinnedCount() != 2 {
 		t.Fatalf("expected 2 pinned rows, got %d", tv.GetPinnedCount())


### PR DESCRIPTION

<img width="1214" height="426" alt="CleanShot 2026-02-06 at 17 59 06@2x" src="https://github.com/user-attachments/assets/9ef6abfd-ab2c-469a-a288-0ee21bd55234" />

## Summary
- Format PostgreSQL UUID columns as `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` instead of raw byte arrays
- Handle `[16]byte` type returned by pgx driver in both query executor and metadata data layer

Closes #4

## Test plan
- [x] Create a table with UUID columns and verify values display correctly
- [x] Verify existing data types (text, integer, JSONB, etc.) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of PostgreSQL UUID values so they are consistently recognized and formatted as standard UUID strings in query results.

* **Tests**
  * Minor test adjustments to suppress returned errors in pin-related table view tests (no behavior change for end users).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->